### PR TITLE
LPD-77251 Validate site name length inline when creating a site

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/add_group.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/add_group.jsp
@@ -27,7 +27,9 @@ AddGroupDisplayContext addGroupDisplayContext = (AddGroupDisplayContext)request.
 	>
 		<div class="add-group-content">
 			<div class="lfr-form-content">
-				<aui:input label="name" name="name" required="<%= true %>" />
+				<aui:input label="name" name="name" required="<%= true %>">
+					<aui:validator name="maxLength"><%= ModelHintsUtil.getMaxLength(Group.class.getName(), "groupKey") %></aui:validator>
+				</aui:input>
 
 				<c:if test="<%= addGroupDisplayContext.isShowLayoutSetVisibilityPrivateCheckbox() %>">
 					<aui:input label="create-default-pages-as-private-available-only-to-members-if-unchecked-they-will-be-public-available-to-anyone" name="layoutSetVisibilityPrivate" type="checkbox" />

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -54,6 +54,7 @@ page import="com.liferay.portal.kernel.model.Layout" %><%@
 page import="com.liferay.portal.kernel.model.LayoutSet" %><%@
 page import="com.liferay.portal.kernel.model.LayoutSetPrototype" %><%@
 page import="com.liferay.portal.kernel.model.MembershipRequest" %><%@
+page import="com.liferay.portal.kernel.model.ModelHintsUtil" %><%@
 page import="com.liferay.portal.kernel.model.Organization" %><%@
 page import="com.liferay.portal.kernel.model.Portlet" %><%@
 page import="com.liferay.portal.kernel.model.SiteConstants" %><%@

--- a/modules/test/playwright/tests/site-admin-web/main/sites.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/main/sites.spec.ts
@@ -78,6 +78,35 @@ test('User can add and delete site and child site', async ({
 	await expect(page.getByText(parentSiteName)).not.toBeVisible();
 });
 
+test(
+	'Site name exceeding character limit shows inline field validation',
+	{tag: '@LPD-77251'},
+	async ({page, sitesAdminPage}) => {
+		await sitesAdminPage.goto();
+
+		await page.getByRole('link', {name: 'Add Site'}).click();
+
+		await page
+			.getByRole('button', {name: 'Select Template: Blank Site'})
+			.click();
+
+		const addSiteIFrame = page.frameLocator('iframe[title="Add Site"]');
+
+		await addSiteIFrame.getByLabel('Name').fill('a'.repeat(151));
+
+		await addSiteIFrame.getByRole('button', {name: 'Add'}).click();
+
+		await expect(
+			addSiteIFrame.getByText('Please enter no more than 150 characters.')
+		).toBeVisible();
+
+		await expect(addSiteIFrame.getByLabel('Name')).toHaveAttribute(
+			'aria-invalid',
+			'true'
+		);
+	}
+);
+
 test('Site is still created even if modal window is closed', async ({
 	page,
 	sitesAdminPage,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-77251

## What Is Being Fixed

When creating a new site, the name field had no length validation. Entering a name longer than the underlying `groupKey` column limit (150 characters) was only rejected after submission, surfacing a generic error alert with no indication of what went wrong or what the limit was.

## How It Is Being Fixed

An `aui:validator` of type `maxLength` is added to the name input in `add_group.jsp`, with the limit sourced from `ModelHintsUtil.getMaxLength(Group.class.getName(), "groupKey")` so it stays in sync with the model definition rather than being hardcoded. This validates the field inline before submission and shows a clear "Please enter no more than 150 characters." message. `init.jsp` imports `ModelHintsUtil` to support this.

## PR Check

**pr-check: PASS** — tested on `b783ed775d76ab4aa54ce0f61476abcec8ae7155`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JSP Compile | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "b783ed775d76ab4aa54ce0f61476abcec8ae7155"} -->
